### PR TITLE
Fix integer strip bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2025-01-27
+
+### Fixed
+- **Integer Values in Table Cells**: Fixed `.strip()` AttributeError when using integer values in table cells
+  - Convert values to strings before calling `.strip()` to handle non-string types
+  - Fixes both header and cell value processing in TableBuilder
+  - Maintains backward compatibility with existing string values
+  - Added comprehensive test coverage for integer values in tables
+
+### Technical Improvements
+- **Robust Type Handling**: Enhanced table cell processing to handle mixed data types
+- **Test Coverage**: Added `test_table_block_with_integers()` to verify fix works correctly
+- **Error Prevention**: Eliminates AttributeError when integer values are used in table data
+
+---
+
 ## [1.0.2] - 2025-06-25
 
 ### Fixed

--- a/docxblocks/builders/table.py
+++ b/docxblocks/builders/table.py
@@ -106,13 +106,14 @@ class TableBuilder:
             for i, header_text in enumerate(headers):
                 cell = row[i]
                 para = cell.paragraphs[0]
-                # Handle empty header text
-                header_display = header_text.strip() if header_text else DEFAULT_EMPTY_VALUE_TEXT
+                # Handle empty header text - convert to string first to avoid .strip() on integers
+                header_str = str(header_text) if header_text is not None else ""
+                header_display = header_str.strip() if header_str else DEFAULT_EMPTY_VALUE_TEXT
                 run = para.add_run(str(header_display))
                 run.font.bold = True
 
                 # Apply placeholder style if header is empty
-                if not header_text or not header_text.strip():
+                if not header_text or not header_str.strip():
                     run.font.bold = DEFAULT_EMPTY_VALUE_STYLE.get("bold", True)
                     if DEFAULT_EMPTY_VALUE_STYLE.get("font_color"):
                         run.font.color.rgb = RGBColor.from_string(DEFAULT_EMPTY_VALUE_STYLE["font_color"])
@@ -132,13 +133,14 @@ class TableBuilder:
             for col_idx, cell_val in enumerate(row_data):
                 cell = cells[col_idx]
                 para = cell.paragraphs[0]
-                # Handle empty cell value
-                cell_display = cell_val.strip() if cell_val else DEFAULT_EMPTY_VALUE_TEXT
+                # Handle empty cell value - convert to string first to avoid .strip() on integers
+                cell_str = str(cell_val) if cell_val is not None else ""
+                cell_display = cell_str.strip() if cell_str else DEFAULT_EMPTY_VALUE_TEXT
                 run = para.add_run(str(cell_display))
                 run.font.bold = False
 
                 # Apply placeholder style if cell is empty
-                if not cell_val or not cell_val.strip():
+                if not cell_val or not cell_str.strip():
                     run.font.bold = DEFAULT_EMPTY_VALUE_STYLE.get("bold", True)
                     if DEFAULT_EMPTY_VALUE_STYLE.get("font_color"):
                         run.font.color.rgb = RGBColor.from_string(DEFAULT_EMPTY_VALUE_STYLE["font_color"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docxblocks"
-version = "1.0.2"
+version = "1.0.4"
 description = "High-level block-based abstraction over python-docx for building dynamic Word documents in code."
 readme = "README.md"
 authors = [

--- a/tests/test_table_block.py
+++ b/tests/test_table_block.py
@@ -33,4 +33,60 @@ def test_table_block(tmp_path):
     # Check that table exists and has correct number of rows
     tables = doc2.tables
     assert len(tables) == 1
-    assert len(tables[0].rows) == 3  # header + 2 rows 
+    assert len(tables[0].rows) == 3  # header + 2 rows
+
+
+def test_table_block_with_integers(tmp_path):
+    """Test that integer values in table cells work correctly without .strip() errors."""
+    template = tmp_path / "template.docx"
+    output = tmp_path / "output.docx"
+    doc = Document()
+    doc.add_paragraph("{{main}}")
+    doc.save(str(template))
+
+    blocks = [
+        {
+            "type": "table",
+            "content": {
+                "headers": ["Name", "Age", "Score"],
+                "rows": [
+                    ["Alice", 25, 95.5],
+                    ["Bob", 30, 87],
+                    ["Charlie", 22, 92.8]
+                ]
+            },
+            "style": {
+                "header_styles": {"bold": True},
+                "column_styles": {1: {"align": "center"}, 2: {"align": "right"}}
+            }
+        }
+    ]
+    builder = DocxBuilder(str(template))
+    builder.insert("{{main}}", blocks)
+    builder.save(str(output))
+
+    assert os.path.exists(output)
+    doc2 = Document(str(output))
+    tables = doc2.tables
+    assert len(tables) == 1
+    assert len(tables[0].rows) == 4  # header + 3 rows
+    
+    # Verify the content is correctly displayed
+    table = tables[0]
+    # Check headers
+    assert table.cell(0, 0).text.strip() == "Name"
+    assert table.cell(0, 1).text.strip() == "Age"
+    assert table.cell(0, 2).text.strip() == "Score"
+    
+    # Check data rows
+    assert table.cell(1, 0).text.strip() == "Alice"
+    assert table.cell(1, 1).text.strip() == "25"
+    assert table.cell(1, 2).text.strip() == "95.5"
+    
+    assert table.cell(2, 0).text.strip() == "Bob"
+    assert table.cell(2, 1).text.strip() == "30"
+    assert table.cell(2, 2).text.strip() == "87"
+    
+    assert table.cell(3, 0).text.strip() == "Charlie"
+    assert table.cell(3, 1).text.strip() == "22"
+    assert table.cell(3, 2).text.strip() == "92.8" 


### PR DESCRIPTION
# Fix integer strip bug
- **Integer Values in Table Cells**: Fixed `.strip()` AttributeError when using integer values in table cells
  - Convert values to strings before calling `.strip()` to handle non-string types
  - Fixes both header and cell value processing in TableBuilder
  - Maintains backward compatibility with existing string values
  - Added comprehensive test coverage for integer values in tables

## Technical Improvements
- **Robust Type Handling**: Enhanced table cell processing to handle mixed data types
- **Test Coverage**: Added `test_table_block_with_integers()` to verify fix works correctly
- **Error Prevention**: Eliminates AttributeError when integer values are used in table data