### PR TITLE
fix: address inline text handling after new paragraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2025-01-27
+
+### Fixed
+- **Inline Text After New Paragraph**: Fixed a bug where a text block following a block with `"new_paragraph": True` would incorrectly start a new paragraph. Now, inline text after a new paragraph block is correctly added to the same paragraph, as expected.
+- Added a test to ensure this behavior remains correct.
+
+---
+
 ## [1.2.0] - 2025-01-27
 
 ### Added

--- a/docxblocks/builders/rich_text.py
+++ b/docxblocks/builders/rich_text.py
@@ -93,8 +93,8 @@ class RichTextBuilder:
         Args:
             block: A validated TextBlock object
         """
-        # Create text builder if it doesn't exist or if this is a new paragraph block
-        if self.text_builder is None or block.new_paragraph:
+        # Create text builder if it doesn't exist
+        if self.text_builder is None:
             self.text_builder = TextBuilder(self.doc, self.parent, self.index)
         
         self.text_builder.build(block)

--- a/docxblocks/builders/text.py
+++ b/docxblocks/builders/text.py
@@ -71,13 +71,9 @@ class TextBuilder:
             else:
                 apply_style_to_run(run, block.style)
         else:
-            # Reset current paragraph for new paragraph text
-            self.current_paragraph = None
-            
-            # Handle multi-line text for new paragraphs
+            # If text contains newlines, create a paragraph for each line
             lines = text.split("\n")
-            
-            for line in lines:
+            for i, line in enumerate(lines):
                 para = self.doc.add_paragraph(
                     style=block.style.style if block.style and block.style.style else "Normal"
                 )
@@ -88,7 +84,8 @@ class TextBuilder:
                     apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
                 else:
                     apply_style_to_run(run, block.style)
-                    
+                
                 set_paragraph_alignment(para, block.style.align if block.style else None)
                 self.parent.insert(self.index, para._element)
-                self.index += 1 
+                self.index += 1
+                self.current_paragraph = para 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docxblocks"
-version = "1.2.0"
+version = "1.2.1"
 description = "High-level block-based abstraction over python-docx for building dynamic Word documents in code."
 readme = "README.md"
 authors = [

--- a/tests/test_inline_text.py
+++ b/tests/test_inline_text.py
@@ -27,21 +27,17 @@ def test_inline_text_default(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Should have 3 paragraphs: inline text, new paragraph text, inline text
+    # Should have 2 paragraphs: inline text, new paragraph text + inline text
     paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
-    assert len(paragraphs) == 3
+    assert len(paragraphs) == 2
     
     # First paragraph should contain all the inline text
     first_para = paragraphs[0]
     assert "Participant Name: John Doe (ID: 12345)" in first_para
     
-    # Second paragraph should contain the new paragraph text
+    # Second paragraph should contain the new paragraph text and the inline text after it
     second_para = paragraphs[1]
-    assert "New line starts here" in second_para
-    
-    # Third paragraph should contain the inline text after new paragraph
-    third_para = paragraphs[2]
-    assert "This should be on the same line as above" in third_para
+    assert "New line starts hereThis should be on the same line as above" in second_para
 
 def test_mixed_inline_and_paragraphs(tmp_path):
     """Test mixing inline text with other block types"""

--- a/tests/test_inline_text.py
+++ b/tests/test_inline_text.py
@@ -78,4 +78,31 @@ def test_mixed_inline_and_paragraphs(tmp_path):
     assert "Summary" in paragraphs[1]
     
     # Third paragraph should contain inline summary text
-    assert "This is a summary of the report." in paragraphs[2] 
+    assert "This is a summary of the report." in paragraphs[2]
+
+def test_inline_after_new_paragraph(tmp_path):
+    """Test that inline text works correctly after a new_paragraph block"""
+    template = tmp_path / "template.docx"
+    output = tmp_path / "output.docx"
+    doc = Document()
+    doc.add_paragraph("{{main}}")
+    doc.save(str(template))
+
+    blocks = [
+        {"type": "text", "text": "Participant No: ", "style": {"bold": True}, "new_paragraph": True},
+        {"type": "text", "text": "12345", "style": {"bold": True}},
+    ]
+    
+    builder = DocxBuilder(str(template))
+    builder.insert("{{main}}", blocks)
+    builder.save(str(output))
+
+    assert os.path.exists(output)
+    doc2 = Document(str(output))
+    
+    # Should have only 1 paragraph with both pieces of text
+    paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
+    assert len(paragraphs) == 1
+    
+    # The paragraph should contain both pieces of text
+    assert "Participant No: 12345" in paragraphs[0] 


### PR DESCRIPTION
- Fixed a bug where inline text following a block with `new_paragraph` incorrectly started a new paragraph.
- Updated `TextBuilder` logic to ensure inline text is added to the same paragraph as expected.
- Added a test to verify the correct behavior of inline text after a new paragraph block.
- Bumped version in `pyproject.toml` to 1.2.1 and updated CHANGELOG.md accordingly.