### PR TITLE
[1.3.1] - 2025-06-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.1] - 2025-06-26
+
+### Fixed
+- **Block Order Preservation**: Blocks are now rendered in the exact order provided to `DocxBuilder.insert()`. The previous logic could result in blocks appearing out of order due to ambiguous validation; this is now resolved.
+- **Validation Logic**: Block validation now uses the `type` field to select the correct schema, preventing accidental misclassification and ensuring robust, predictable rendering.
+- **Test Suite Cleanup**: Tests are now logically grouped, redundant code and files have been removed, and the suite is easier to maintain and extend.
+
 ## [Unreleased]
 
 ### Planned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - 2025-01-27
+---
+
+## [1.3.1] - 2025-06-26
+
+### Fixed
+- **Block Order Preservation**: Blocks are now rendered in the exact order provided to `DocxBuilder.insert()`. The previous logic could result in blocks appearing out of order due to ambiguous validation; this is now resolved.
+- **Validation Logic**: Block validation now uses the `type` field to select the correct schema, preventing accidental misclassification and ensuring robust, predictable rendering.
+- **Test Suite Cleanup**: Tests are now logically grouped, redundant code and files have been removed, and the suite is easier to maintain and extend.
+
+## [Unreleased]
+
+### Planned
+- Additional block types (charts, page breaks, etc.)
+- More styling options (underline, strikethrough, etc.)
+- Template inheritance and composition
+- Performance optimizations for large documents 
+
+--- 
+
+## [1.3.0] - 2025-06-26
 
 ### Added
 - **Smart Newline Handling**: Text blocks now intelligently handle newline characters
@@ -36,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.2.2] - 2025-01-27
+## [1.2.2] - 2025-06-25
 
 ### Fixed
 - **Inline Text After New Paragraph**: Fixed a bug where a text block following a block with `"new_paragraph": True` would incorrectly start a new paragraph. Now, inline text after a new paragraph block is correctly added to the same paragraph, as expected.
@@ -53,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [1.2.0] - 2025-01-27
+## [1.2.0] - 2025-06-25
 
 ### Added
 - **Page Break Blocks**: New `page_break` block type for creating multi-page documents
@@ -209,20 +228,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - python-docx >= 0.8.11
 - Pillow >= 10.0.0
 - pydantic >= 2.0.0
-
----
-
-## [1.3.1] - 2025-06-26
-
-### Fixed
-- **Block Order Preservation**: Blocks are now rendered in the exact order provided to `DocxBuilder.insert()`. The previous logic could result in blocks appearing out of order due to ambiguous validation; this is now resolved.
-- **Validation Logic**: Block validation now uses the `type` field to select the correct schema, preventing accidental misclassification and ensuring robust, predictable rendering.
-- **Test Suite Cleanup**: Tests are now logically grouped, redundant code and files have been removed, and the suite is easier to maintain and extend.
-
-## [Unreleased]
-
-### Planned
-- Additional block types (charts, page breaks, etc.)
-- More styling options (underline, strikethrough, etc.)
-- Template inheritance and composition
-- Performance optimizations for large documents 

--- a/docxblocks/builders/rich_text.py
+++ b/docxblocks/builders/rich_text.py
@@ -60,16 +60,32 @@ class RichTextBuilder:
         """
         validated_blocks = []
         for b in blocks:
-            # Try to validate as each block type
-            for block_class in [TextBlock, HeadingBlock, BulletBlock, TableBlock, ImageBlock, PageBreakBlock]:
-                try:
-                    validated_block = block_class.model_validate(b)
-                    validated_blocks.append(validated_block)
-                    break
-                except:
-                    continue
-            else:
-                # If no block type matches, skip this block
+            # Get the block type from the dictionary
+            block_type = b.get('type')
+            if not block_type:
+                continue
+                
+            # Map block types to their corresponding classes
+            block_class_map = {
+                'text': TextBlock,
+                'heading': HeadingBlock,
+                'bullets': BulletBlock,
+                'table': TableBlock,
+                'image': ImageBlock,
+                'page_break': PageBreakBlock
+            }
+            
+            # Get the appropriate block class
+            block_class = block_class_map.get(block_type)
+            if not block_class:
+                continue
+                
+            # Validate the block
+            try:
+                validated_block = block_class.model_validate(b)
+                validated_blocks.append(validated_block)
+            except:
+                # If validation fails, skip this block
                 continue
                 
         for block in validated_blocks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docxblocks"
-version = "1.3.0"
+version = "1.3.1"
 description = "High-level block-based abstraction over python-docx for building dynamic Word documents in code."
 readme = "README.md"
 authors = [

--- a/tests/test_block_order.py
+++ b/tests/test_block_order.py
@@ -1,0 +1,136 @@
+import os
+from docx import Document
+from docxblocks.core.inserter import DocxBuilder
+
+def test_block_order_preservation(tmp_path):
+    """Test that blocks are processed in the exact order they are provided"""
+    template = tmp_path / "template.docx"
+    output = tmp_path / "output.docx"
+    doc = Document()
+    doc.add_paragraph("{{main}}")
+    doc.save(str(template))
+
+    # Create blocks in a specific order
+    blocks = [
+        {"type": "heading", "text": "First Block", "level": 1},
+        {"type": "text", "text": "Second Block", "new_paragraph": True},
+        {"type": "heading", "text": "Third Block", "level": 2},
+        {"type": "text", "text": "Fourth Block", "new_paragraph": True},
+        {"type": "bullets", "items": ["Fifth Block - Item 1", "Fifth Block - Item 2"]},
+        {"type": "text", "text": "Sixth Block", "new_paragraph": True},
+    ]
+    
+    builder = DocxBuilder(str(template))
+    builder.insert("{{main}}", blocks)
+    builder.save(str(output))
+
+    assert os.path.exists(output)
+    doc2 = Document(str(output))
+    
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
+    
+    # Verify the order matches our expected sequence
+    expected_order = [
+        "First Block",  # Heading 1
+        "Second Block",  # Text
+        "Third Block",   # Heading 2
+        "Fourth Block",  # Text
+        "Fifth Block - Item 1",  # First bullet
+        "Fifth Block - Item 2",  # Second bullet
+        "Sixth Block",   # Text
+    ]
+    
+    # Check that we have the right number of paragraphs
+    assert len(paragraphs) == len(expected_order), f"Expected {len(expected_order)} paragraphs, got {len(paragraphs)}"
+    
+    # Check that each paragraph appears in the correct order
+    for i, expected in enumerate(expected_order):
+        assert expected in paragraphs[i], f"Expected '{expected}' at position {i}, but found '{paragraphs[i]}'"
+
+def test_mixed_block_types_order(tmp_path):
+    """Test that mixed block types maintain their order"""
+    template = tmp_path / "template.docx"
+    output = tmp_path / "output.docx"
+    doc = Document()
+    doc.add_paragraph("{{main}}")
+    doc.save(str(template))
+
+    # Create blocks with mixed types in specific order
+    blocks = [
+        {"type": "text", "text": "Start", "new_paragraph": True},
+        {"type": "heading", "text": "Section 1", "level": 1},
+        {"type": "text", "text": "Content 1", "new_paragraph": True},
+        {"type": "table", "content": {"headers": ["Col1"], "rows": [["Data1"]]}},
+        {"type": "text", "text": "Content 2", "new_paragraph": True},
+        {"type": "heading", "text": "Section 2", "level": 2},
+        {"type": "bullets", "items": ["Item 1", "Item 2"]},
+        {"type": "text", "text": "End", "new_paragraph": True},
+    ]
+    
+    builder = DocxBuilder(str(template))
+    builder.insert("{{main}}", blocks)
+    builder.save(str(output))
+
+    assert os.path.exists(output)
+    doc2 = Document(str(output))
+    
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
+    
+    # Verify the order - we should see text and headings in order
+    expected_text_order = [
+        "Start",
+        "Section 1", 
+        "Content 1",
+        "Content 2",
+        "Section 2",
+        "Item 1",
+        "Item 2", 
+        "End"
+    ]
+    
+    # Check that we have the right number of text paragraphs
+    assert len(paragraphs) == len(expected_text_order), f"Expected {len(expected_text_order)} text paragraphs, got {len(paragraphs)}"
+    
+    # Check that each text paragraph appears in the correct order
+    for i, expected in enumerate(expected_text_order):
+        assert expected in paragraphs[i], f"Expected '{expected}' at position {i}, but found '{paragraphs[i]}'"
+    
+    # Also verify that tables are present (they don't add text paragraphs)
+    tables = doc2.tables
+    assert len(tables) == 1, "Expected 1 table to be present"
+
+def test_inline_text_order(tmp_path):
+    """Test that inline text blocks maintain their order"""
+    template = tmp_path / "template.docx"
+    output = tmp_path / "output.docx"
+    doc = Document()
+    doc.add_paragraph("{{main}}")
+    doc.save(str(template))
+
+    # Create inline text blocks that should stay in order
+    blocks = [
+        {"type": "text", "text": "First "},
+        {"type": "text", "text": "Second "},
+        {"type": "text", "text": "Third", "new_paragraph": True},
+        {"type": "text", "text": "Fourth "},
+        {"type": "text", "text": "Fifth", "new_paragraph": True},
+    ]
+    
+    builder = DocxBuilder(str(template))
+    builder.insert("{{main}}", blocks)
+    builder.save(str(output))
+
+    assert os.path.exists(output)
+    doc2 = Document(str(output))
+    
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
+    
+    # The text builder creates separate paragraphs for each new_paragraph=True block
+    # So we should have: "First Second", "Third", "Fourth Fifth"
+    assert len(paragraphs) == 3
+    assert "First Second" in paragraphs[0]
+    assert "Third" in paragraphs[1]
+    assert "Fourth Fifth" in paragraphs[2] 


### PR DESCRIPTION
### Fixed
- **Block Order Preservation**: Blocks are now rendered in the exact order provided to `DocxBuilder.insert()`. The previous logic could result in blocks appearing out of order due to ambiguous validation; this is now resolved.
- **Validation Logic**: Block validation now uses the `type` field to select the correct schema, preventing accidental misclassification and ensuring robust, predictable rendering.
- **Test Suite Cleanup**: Tests are now logically grouped, redundant code and files have been removed, and the suite is easier to maintain and extend.