### PR TITLE
[1.3.2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,3 +228,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More styling options (underline, strikethrough, etc.)
 - Template inheritance and composition
 - Performance optimizations for large documents 
+
+## [v1.3.2] - YYYY-MM-DD
+
+### Added
+- Generic newline handling: every `\n` creates a new paragraph everywhere (text blocks, inline text, table cells, table headers).
+- `spacing` parameter is supported for text blocks, adding extra blank paragraphs after the block.
+
+### Changed
+- All text is now consistent inside and outside tables. No more grouping of inline text blocks; each block is its own paragraph.
+- Table cells and headers treat every `\n` as a new paragraph, including empty ones for `\n\n`.
+
+### Fixed
+- All tests updated to match the new behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.2] - 2025-06-26
+
+### Added
+- Generic newline handling: every `\n` creates a new paragraph everywhere (text blocks, inline text, table cells, table headers).
+- `spacing` parameter is supported for text blocks, adding extra blank paragraphs after the block.
+
+### Changed
+- All text is now consistent inside and outside tables. No more grouping of inline text blocks; each block is its own paragraph.
+- Table cells and headers treat every `\n` as a new paragraph, including empty ones for `\n\n`.
+
+### Fixed
+- All tests updated to match the new behavior.
+
+---
+
 ## [1.3.1] - 2025-06-26
 
 ### Fixed
@@ -228,16 +243,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More styling options (underline, strikethrough, etc.)
 - Template inheritance and composition
 - Performance optimizations for large documents 
-
-## [v1.3.2] - YYYY-MM-DD
-
-### Added
-- Generic newline handling: every `\n` creates a new paragraph everywhere (text blocks, inline text, table cells, table headers).
-- `spacing` parameter is supported for text blocks, adding extra blank paragraphs after the block.
-
-### Changed
-- All text is now consistent inside and outside tables. No more grouping of inline text blocks; each block is its own paragraph.
-- Table cells and headers treat every `\n` as a new paragraph, including empty ones for `\n\n`.
-
-### Fixed
-- All tests updated to match the new behavior.

--- a/docxblocks/schema/blocks.py
+++ b/docxblocks/schema/blocks.py
@@ -13,6 +13,7 @@ class TextBlock(BaseBlock):
     text: str = Field(..., description="Text content - can be empty string")
     style: Optional[TextStyle] = None
     new_paragraph: Optional[bool] = Field(default=False, description="If True, text will start a new paragraph. If False (default), text will be inline with previous text")
+    spacing: Optional[int] = Field(default=1, ge=1, le=5, description="Number of blank lines to insert after this text block")
 
 
 class HeadingBlock(BaseBlock):

--- a/docxblocks/utils/text_processing.py
+++ b/docxblocks/utils/text_processing.py
@@ -12,11 +12,10 @@ from docxblocks.constants import DEFAULT_EMPTY_VALUE_STYLE
 
 def process_text_with_newlines(doc, text, style=None, is_empty=False):
     """
-    Process text content and handle \n\n patterns by creating paragraphs with blank lines.
+    Process text content and handle newlines by creating new paragraphs.
     
-    This function splits text by \n\n and creates separate paragraphs for each part,
-    with blank paragraphs inserted between them. Single \n characters remain as
-    literal newlines within paragraphs.
+    This function splits text by \n and creates separate paragraphs for each part.
+    Every \n creates a new paragraph, including empty ones.
     
     Args:
         doc: The python-docx Document object
@@ -29,53 +28,25 @@ def process_text_with_newlines(doc, text, style=None, is_empty=False):
     """
     paragraphs = []
     
-    # Check for \n\n pattern and handle it specially
-    if "\n\n" in text:
-        # Split by \n\n to separate content that should be in different paragraphs
-        parts = text.split("\n\n")
-        for i, part in enumerate(parts):
-            if i > 0:
-                # Add a blank line before the new paragraph
-                blank_para = doc.add_paragraph(
-                    style=style.style if style and style.style else "Normal"
-                )
-                paragraphs.append(blank_para._element)
-                
-                # Create new paragraph for this part
-                para = doc.add_paragraph(
-                    style=style.style if style and style.style else "Normal"
-                )
-                paragraphs.append(para._element)
-            else:
-                # Create paragraph for the first part
-                para = doc.add_paragraph(
-                    style=style.style if style and style.style else "Normal"
-                )
-                paragraphs.append(para._element)
-            
-            # Add the part as a run to the current paragraph
-            if part:  # Only add non-empty parts
-                run = para.add_run(part)
-                
-                # Apply block style, but override with placeholder style if text is empty
-                if is_empty:
-                    apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
-                else:
-                    apply_style_to_run(run, style)
-    else:
-        # No \n\n found, create a single paragraph
+    # Split by \n to handle all newlines as paragraph breaks
+    parts = text.split("\n")
+    
+    for i, part in enumerate(parts):
+        # Create new paragraph for this part (including empty ones)
         para = doc.add_paragraph(
             style=style.style if style and style.style else "Normal"
         )
-        run = para.add_run(text)
-        
-        # Apply block style, but override with placeholder style if text is empty
-        if is_empty:
-            apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
-        else:
-            apply_style_to_run(run, style)
-        
         paragraphs.append(para._element)
+        
+        # Add the part as a run to the current paragraph
+        if part:  # Only add non-empty parts
+            run = para.add_run(part)
+            
+            # Apply block style, but override with placeholder style if text is empty
+            if is_empty:
+                apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
+            else:
+                apply_style_to_run(run, style)
     
     return paragraphs
 
@@ -85,7 +56,8 @@ def add_text_to_cell(cell, text, style=None, is_empty=False):
     Add text content to a table cell with proper newline handling.
     
     This function processes text content and adds it to a table cell,
-    handling \n\n patterns by creating multiple paragraphs within the cell.
+    handling \n patterns by creating multiple paragraphs within the cell.
+    Behaves exactly like process_text_with_newlines for consistency.
     
     Args:
         cell: The table cell element
@@ -93,50 +65,24 @@ def add_text_to_cell(cell, text, style=None, is_empty=False):
         style: TextStyle object for styling (optional)
         is_empty: Whether the original text was empty (for placeholder styling)
     """
-    # Clear existing content
+    # Clear all existing paragraphs in the cell
     for paragraph in cell.paragraphs:
-        for run in paragraph.runs:
-            run.text = ""
+        p = paragraph._element
+        p.getparent().remove(p)
     
-    # Check for \n\n pattern and handle it specially
-    if "\n\n" in text:
-        # Split by \n\n to separate content that should be in different paragraphs
-        parts = text.split("\n\n")
-        for i, part in enumerate(parts):
-            if i > 0:
-                # Add a blank paragraph before the new content
-                blank_para = cell.add_paragraph()
-                blank_para.text = ""
-                
-                # Create new paragraph for this part
-                para = cell.add_paragraph()
-            else:
-                # Use the first paragraph or create one if needed
-                if cell.paragraphs:
-                    para = cell.paragraphs[0]
-                else:
-                    para = cell.add_paragraph()
+    # Split by \n to handle all newlines as paragraph breaks
+    parts = text.split("\n")
+    
+    for i, part in enumerate(parts):
+        # Create new paragraph for this part (including empty ones)
+        para = cell.add_paragraph()
+        
+        # Add the part as a run to the current paragraph
+        if part:  # Only add non-empty parts
+            run = para.add_run(part)
             
-            # Add the part as a run to the current paragraph
-            if part:  # Only add non-empty parts
-                run = para.add_run(part)
-                
-                # Apply block style, but override with placeholder style if text is empty
-                if is_empty:
-                    apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
-                else:
-                    apply_style_to_run(run, style)
-    else:
-        # No \n\n found, add text to the first paragraph
-        if cell.paragraphs:
-            para = cell.paragraphs[0]
-        else:
-            para = cell.add_paragraph()
-        
-        run = para.add_run(text)
-        
-        # Apply block style, but override with placeholder style if text is empty
-        if is_empty:
-            apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
-        else:
-            apply_style_to_run(run, style) 
+            # Apply block style, but override with placeholder style if text is empty
+            if is_empty:
+                apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
+            else:
+                apply_style_to_run(run, style)

--- a/tests/test_block_order.py
+++ b/tests/test_block_order.py
@@ -102,14 +102,14 @@ def test_mixed_block_types_order(tmp_path):
     assert len(tables) == 1, "Expected 1 table to be present"
 
 def test_inline_text_order(tmp_path):
-    """Test that inline text blocks maintain their order and grouping"""
+    """Test that inline text blocks each create their own paragraph"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
     doc.add_paragraph("{{main}}")
     doc.save(str(template))
 
-    # Create inline text blocks that should stay in order
+    # Create inline text blocks that should each be a paragraph
     blocks = [
         {"type": "text", "text": "First "},
         {"type": "text", "text": "Second "},
@@ -128,10 +128,10 @@ def test_inline_text_order(tmp_path):
     # Get all paragraphs with text content
     paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
 
-    # The text builder creates separate paragraphs for each new_paragraph=True block
-    # So we should have: "First Second", "Third", "Fourth", "Fifth"
-    assert len(paragraphs) == 4
-    assert "First Second" in paragraphs[0]
-    assert "Third" in paragraphs[1]
-    assert "Fourth" in paragraphs[2]
-    assert "Fifth" in paragraphs[3] 
+    # Each block is now its own paragraph
+    assert len(paragraphs) == 5
+    assert "First" in paragraphs[0]
+    assert "Second" in paragraphs[1]
+    assert "Third" in paragraphs[2]
+    assert "Fourth" in paragraphs[3]
+    assert "Fifth" in paragraphs[4] 

--- a/tests/test_inline_text.py
+++ b/tests/test_inline_text.py
@@ -3,7 +3,7 @@ from docx import Document
 from docxblocks.core.inserter import DocxBuilder
 
 def test_inline_text_default(tmp_path):
-    """Test that text blocks are inline by default (no new paragraphs)"""
+    """Test that text blocks each create their own paragraph (no grouping)"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -27,24 +27,19 @@ def test_inline_text_default(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Should have 3 paragraphs: inline text, new paragraph text, inline text after new paragraph
+    # Each block is now its own paragraph
     paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
-    assert len(paragraphs) == 3
-    
-    # First paragraph should contain all the inline text
-    first_para = paragraphs[0]
-    assert "Participant Name: John Doe (ID: 12345)" in first_para
-    
-    # Second paragraph should contain the new paragraph text
-    second_para = paragraphs[1]
-    assert "New line starts here" in second_para
-    
-    # Third paragraph should contain the inline text after the new paragraph
-    third_para = paragraphs[2]
-    assert "This should be on the same line as above" in third_para
+    assert len(paragraphs) == 7
+    assert "Participant Name: " in paragraphs[0]
+    assert "John Doe" in paragraphs[1]
+    assert " (ID: " in paragraphs[2]
+    assert "12345" in paragraphs[3]
+    assert ")" in paragraphs[4]
+    assert "New line starts here" in paragraphs[5]
+    assert "This should be on the same line as above" in paragraphs[6]
 
 def test_mixed_inline_and_paragraphs(tmp_path):
-    """Test mixing inline text with other block types"""
+    """Test mixing inline text with other block types, all text blocks are separate paragraphs"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -67,21 +62,18 @@ def test_mixed_inline_and_paragraphs(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Should have 3 paragraphs: inline text, heading, inline text
+    # Each text block is now its own paragraph
     paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
-    assert len(paragraphs) == 3
-    
-    # First paragraph should contain inline status text
-    assert "Status: Active" in paragraphs[0]
-    
-    # Second paragraph should be the heading
-    assert "Summary" in paragraphs[1]
-    
-    # Third paragraph should contain inline summary text
-    assert "This is a summary of the report." in paragraphs[2]
+    assert len(paragraphs) == 6
+    assert "Status: " in paragraphs[0]
+    assert "Active" in paragraphs[1]
+    assert "Summary" in paragraphs[2]
+    assert "This is a " in paragraphs[3]
+    assert "summary" in paragraphs[4]
+    assert " of the report." in paragraphs[5]
 
 def test_inline_after_new_paragraph(tmp_path):
-    """Test that inline text works correctly after a new_paragraph block"""
+    """Test that each text block after a new_paragraph is its own paragraph"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -100,12 +92,8 @@ def test_inline_after_new_paragraph(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Should have 2 paragraphs: new paragraph text and inline text after it
+    # Each block is now its own paragraph
     paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
     assert len(paragraphs) == 2
-    
-    # First paragraph should contain the new paragraph text
     assert "Participant No: " in paragraphs[0]
-    
-    # Second paragraph should contain the inline text after the new paragraph
     assert "12345" in paragraphs[1] 

--- a/tests/test_page_break.py
+++ b/tests/test_page_break.py
@@ -35,7 +35,7 @@ def test_page_break_simple(tmp_path):
     assert "After page break" in text_paragraphs[1].text
 
 def test_page_break_with_inline_text(tmp_path):
-    """Test that page breaks work correctly with inline text"""
+    """Test that page breaks work correctly with each text block as its own paragraph"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -57,14 +57,10 @@ def test_page_break_with_inline_text(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Should have 2 text paragraphs (inline text combined) plus page break
+    # Each text block is now its own paragraph
     all_paragraphs = list(doc2.paragraphs)
-    assert len(all_paragraphs) == 3  # Two text paragraphs + page break
-    
-    # Check first paragraph has combined inline text
-    first_para = all_paragraphs[0]
-    assert "First page: inline text" in first_para.text
-    
-    # Check second paragraph has combined inline text
-    second_para = all_paragraphs[2]
-    assert "Second page: more inline text" in second_para.text 
+    assert len(all_paragraphs) == 5  # Four text paragraphs + page break
+    assert "First page: " in all_paragraphs[0].text
+    assert "inline text" in all_paragraphs[1].text
+    assert "Second page: " in all_paragraphs[3].text
+    assert "more inline text" in all_paragraphs[4].text 

--- a/tests/test_table_block.py
+++ b/tests/test_table_block.py
@@ -44,7 +44,7 @@ def test_table_block(tmp_path):
     assert len(table.columns) == 3
 
 def test_table_block_with_integers(tmp_path):
-    """Test table block with integer values"""
+    """Test table block with integer values, each value is its own paragraph"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -71,19 +71,19 @@ def test_table_block_with_integers(tmp_path):
 
     assert os.path.exists(output)
     doc2 = Document(str(output))
-    
+
     # Check that table was created with integer values
     tables = doc2.tables
     assert len(tables) == 1
-    
+
     table = tables[0]
-    # Check that integer values are properly converted to strings
-    assert table.cell(1, 0).text == "1"
-    assert table.cell(1, 1).text == "100"
-    assert table.cell(1, 2).text == "25"
+    # Check that integer values are properly converted to strings, each as its own paragraph
+    assert table.cell(1, 0).paragraphs[0].text.strip() == "1"
+    assert table.cell(2, 0).paragraphs[0].text.strip() == "2"
+    assert table.cell(3, 0).paragraphs[0].text.strip() == "3"
 
 def test_table_cell_with_single_newlines(tmp_path):
-    """Test that single \n in table cells remains as literal newlines"""
+    """Test that single \n in table cells creates new paragraphs"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -109,22 +109,20 @@ def test_table_cell_with_single_newlines(tmp_path):
 
     assert os.path.exists(output)
     doc2 = Document(str(output))
-    
+
     # Check that table was created
     tables = doc2.tables
     assert len(tables) == 1
-    
+
     table = tables[0]
-    
-    # Check first row - should have single paragraph with literal newlines
+
+    # Check first row - should have 3 paragraphs for the description cell
     first_cell = table.cell(1, 1)  # Row 1, Column 1 (description)
     paragraphs = first_cell.paragraphs
-    
-    # Should have only 1 paragraph with literal newlines
-    assert len(paragraphs) == 1
-    
-    # The paragraph should contain all lines with literal \n
-    assert "Line 1\nLine 2\nLine 3" in paragraphs[0].text
+    assert len(paragraphs) == 3
+    assert paragraphs[0].text == "Line 1"
+    assert paragraphs[1].text == "Line 2"
+    assert paragraphs[2].text == "Line 3"
 
 def test_table_cell_with_double_newlines(tmp_path):
     """Test that \n\n in table cells creates new paragraphs with blank lines"""
@@ -153,44 +151,28 @@ def test_table_cell_with_double_newlines(tmp_path):
 
     assert os.path.exists(output)
     doc2 = Document(str(output))
-    
+
     # Check that table was created
     tables = doc2.tables
     assert len(tables) == 1
-    
+
     table = tables[0]
-    
-    # Check first row - should have multiple paragraphs in the description cell
+
+    # Check first row - should have 3 paragraphs for the description cell (including blank)
     first_cell = table.cell(1, 1)  # Row 1, Column 1 (description)
     paragraphs = first_cell.paragraphs
-    
-    # Should have 3 paragraphs: first paragraph, blank line, second paragraph
     assert len(paragraphs) == 3
-    
-    # First paragraph should contain the first part
-    assert "First paragraph." in paragraphs[0].text
-    
-    # Second paragraph should be blank
-    assert not paragraphs[1].text.strip()
-    
-    # Third paragraph should contain the second part
-    assert "Second paragraph with blank line." in paragraphs[2].text
-    
-    # Check second row - should have mixed single and double newlines
-    second_cell = table.cell(2, 1)  # Row 2, Column 1 (description)
-    paragraphs = second_cell.paragraphs
-    
-    # Should have 3 paragraphs: first two lines together, blank line, new paragraph
-    assert len(paragraphs) == 3
-    
-    # First paragraph should contain the first two lines
-    assert "Single line\nAnother line" in paragraphs[0].text
-    
-    # Second paragraph should be blank
-    assert not paragraphs[1].text.strip()
-    
-    # Third paragraph should contain the new paragraph
-    assert "New paragraph." in paragraphs[2].text
+    assert paragraphs[0].text == "First paragraph."
+    assert paragraphs[1].text == ""
+    assert paragraphs[2].text == "Second paragraph with blank line."
+    # Second row, second cell
+    second_cell = table.cell(2, 1)
+    paragraphs2 = second_cell.paragraphs
+    assert len(paragraphs2) == 4
+    assert paragraphs2[0].text == "Single line"
+    assert paragraphs2[1].text == "Another line"
+    assert paragraphs2[2].text == ""
+    assert paragraphs2[3].text == "New paragraph."
 
 def test_table_header_with_double_newlines(tmp_path):
     """Test that \n\n in table headers creates new paragraphs with blank lines"""
@@ -219,25 +201,17 @@ def test_table_header_with_double_newlines(tmp_path):
 
     assert os.path.exists(output)
     doc2 = Document(str(output))
-    
+
     # Check that table was created
     tables = doc2.tables
     assert len(tables) == 1
-    
+
     table = tables[0]
-    
+
     # Check header cell with double newlines
     header_cell = table.cell(0, 1)  # Header row, Column 1
     paragraphs = header_cell.paragraphs
-    
-    # Should have 3 paragraphs: first part, blank line, second part
     assert len(paragraphs) == 3
-    
-    # First paragraph should contain the first part
-    assert "Description" in paragraphs[0].text
-    
-    # Second paragraph should be blank
-    assert not paragraphs[1].text.strip()
-    
-    # Third paragraph should contain the second part
-    assert "Details" in paragraphs[2].text 
+    assert paragraphs[0].text == "Description"
+    assert paragraphs[1].text == ""
+    assert paragraphs[2].text == "Details" 

--- a/tests/test_text_block.py
+++ b/tests/test_text_block.py
@@ -22,8 +22,8 @@ def test_text_block(tmp_path):
     found = any(DEFAULT_EMPTY_VALUE_TEXT in p.text for p in doc2.paragraphs)
     assert found, "Placeholder text not found in output docx"
 
-def test_double_newline_creates_paragraph_with_blank_line(tmp_path):
-    """Test that \n\n creates a new paragraph with a blank line before it"""
+def test_single_newline_creates_paragraph(tmp_path):
+    """Test that single newlines create new paragraphs"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -31,35 +31,26 @@ def test_double_newline_creates_paragraph_with_blank_line(tmp_path):
     doc.save(str(template))
 
     blocks = [
-        {"type": "text", "text": "First paragraph.\n\nSecond paragraph."},
+        {"type": "text", "text": "First line\nSecond line"},
     ]
-    
+
     builder = DocxBuilder(str(template))
     builder.insert("{{main}}", blocks)
     builder.save(str(output))
 
     assert os.path.exists(output)
     doc2 = Document(str(output))
+
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
     
-    # Should have 3 paragraphs: first paragraph, blank line, second paragraph
-    paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
+    # Should have 2 paragraphs from the single newline
     assert len(paragraphs) == 2
-    
-    # First paragraph should contain the first part
-    assert "First paragraph." in paragraphs[0]
-    
-    # Second paragraph should contain the second part
-    assert "Second paragraph." in paragraphs[1]
-    
-    # Check that there's a blank paragraph between them
-    all_paragraphs = list(doc2.paragraphs)
-    assert len(all_paragraphs) == 3  # First, blank, second
-    
-    # The middle paragraph should be blank
-    assert not all_paragraphs[1].text.strip()
+    assert "First line" in paragraphs[0]
+    assert "Second line" in paragraphs[1]
 
-def test_single_newline_remains_inline(tmp_path):
-    """Test that single \n remains as inline text"""
+def test_double_newline_creates_paragraph_with_blank_line(tmp_path):
+    """Test that double newlines create two separate paragraphs"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -67,25 +58,33 @@ def test_single_newline_remains_inline(tmp_path):
     doc.save(str(template))
 
     blocks = [
-        {"type": "text", "text": "Line 1\nLine 2"},
+        {"type": "text", "text": "First paragraph\n\nSecond paragraph"},
     ]
-    
+
     builder = DocxBuilder(str(template))
     builder.insert("{{main}}", blocks)
     builder.save(str(output))
 
     assert os.path.exists(output)
     doc2 = Document(str(output))
+
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
     
-    # Should have only 1 paragraph with both lines
-    paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
-    assert len(paragraphs) == 1
+    # Should have 3 paragraphs: First, empty, Second
+    assert len(paragraphs) == 2
+    assert "First paragraph" in paragraphs[0]
+    assert "Second paragraph" in paragraphs[1]
     
-    # The paragraph should contain both lines with literal \n
-    assert "Line 1\nLine 2" in paragraphs[0]
+    # Count total paragraphs (including empty ones)
+    all_paragraphs = [p.text for p in doc2.paragraphs]
+    
+    # Should have 3 total paragraphs: First, empty, Second
+    assert len(all_paragraphs) == 3
+    assert all_paragraphs[1] == ""  # Empty paragraph from \n\n
 
 def test_mixed_newlines(tmp_path):
-    """Test mixing single and double newlines"""
+    """Test mixed single and double newlines"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -93,29 +92,94 @@ def test_mixed_newlines(tmp_path):
     doc.save(str(template))
 
     blocks = [
-        {"type": "text", "text": "First line\nSecond line\n\nThird paragraph."},
+        {"type": "text", "text": "First\nSecond\n\nThird\nFourth"},
     ]
-    
+
     builder = DocxBuilder(str(template))
     builder.insert("{{main}}", blocks)
     builder.save(str(output))
 
     assert os.path.exists(output)
     doc2 = Document(str(output))
+
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
     
-    # Should have 2 paragraphs: first two lines together, then third paragraph
-    paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
-    assert len(paragraphs) == 2
+    # Should have 4 paragraphs with text: First, Second, Third, Fourth
+    assert len(paragraphs) == 4
+    assert "First" in paragraphs[0]
+    assert "Second" in paragraphs[1]
+    assert "Third" in paragraphs[2]
+    assert "Fourth" in paragraphs[3]
     
-    # First paragraph should contain the first two lines
-    assert "First line\nSecond line" in paragraphs[0]
+    # Count total paragraphs (including empty ones)
+    all_paragraphs = [p.text for p in doc2.paragraphs]
     
-    # Second paragraph should contain the third line
-    assert "Third paragraph." in paragraphs[1]
+    # Should have 5 total paragraphs: First, Second, empty, Third, Fourth
+    assert len(all_paragraphs) == 5
+    assert all_paragraphs[2] == ""  # Empty paragraph from \n\n
+
+def test_spacing_functionality(tmp_path):
+    """Test that spacing parameter adds extra blank lines after text"""
+    template = tmp_path / "template.docx"
+    output = tmp_path / "output.docx"
+    doc = Document()
+    doc.add_paragraph("{{main}}")
+    doc.save(str(template))
+
+    blocks = [
+        {"type": "text", "text": "First paragraph"},
+        {"type": "text", "text": "Second paragraph", "spacing": 2},
+        {"type": "text", "text": "Third paragraph"},
+    ]
+
+    builder = DocxBuilder(str(template))
+    builder.insert("{{main}}", blocks)
+    builder.save(str(output))
+
+    assert os.path.exists(output)
+    doc2 = Document(str(output))
+
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
     
-    # Check that there's a blank paragraph between them
-    all_paragraphs = list(doc2.paragraphs)
-    assert len(all_paragraphs) == 3  # First, blank, second
+    # Should have 3 paragraphs with text
+    assert len(paragraphs) == 3
+    assert "First paragraph" in paragraphs[0]
+    assert "Second paragraph" in paragraphs[1]
+    assert "Third paragraph" in paragraphs[2]
     
-    # The middle paragraph should be blank
-    assert not all_paragraphs[1].text.strip() 
+    # Count total paragraphs (including blank ones)
+    all_paragraphs = [p.text for p in doc2.paragraphs]
+    
+    # Should have 4 total paragraphs: First, Second, blank line, Third
+    assert len(all_paragraphs) == 4
+    assert all_paragraphs[2] == ""  # Blank line from spacing: 2
+
+def test_newlines_create_paragraphs(tmp_path):
+    """Test that all newlines create new paragraphs"""
+    template = tmp_path / "template.docx"
+    output = tmp_path / "output.docx"
+    doc = Document()
+    doc.add_paragraph("{{main}}")
+    doc.save(str(template))
+
+    blocks = [
+        {"type": "text", "text": "Line 1\nLine 2\nLine 3"},
+    ]
+
+    builder = DocxBuilder(str(template))
+    builder.insert("{{main}}", blocks)
+    builder.save(str(output))
+
+    assert os.path.exists(output)
+    doc2 = Document(str(output))
+
+    # Get all paragraphs with text content
+    paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
+    
+    # Should have 3 paragraphs from the single text block with newlines
+    assert len(paragraphs) == 3
+    assert "Line 1" in paragraphs[0]
+    assert "Line 2" in paragraphs[1]
+    assert "Line 3" in paragraphs[2] 


### PR DESCRIPTION
### Added
- Generic newline handling: every `\n` creates a new paragraph everywhere (text blocks, inline text, table cells, table headers).
- `spacing` parameter is supported for text blocks, adding extra blank paragraphs after the block.

### Changed
- All text is now consistent inside and outside tables. No more grouping of inline text blocks; each block is its own paragraph.
- Table cells and headers treat every `\n` as a new paragraph, including empty ones for `\n\n`.

### Fixed
- All tests updated to match the new behavior.