### PR TITLE
[1.3.3] - 2025-06-26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.3.3] - 2025-06-26
+
+### Changed
+- Finalized paragraph and inline grouping rules: consecutive text blocks are grouped inline by default, but any `\n` or `new_paragraph: True` always starts a new paragraph and resets grouping.
+- After a new paragraph, the next inline block starts a new paragraph group.
+- Table cells and headers behave the same way as text blocks.
+- `spacing` parameter only applies to blocks with `new_paragraph: True`.
+
+### Fixed
+- All tests and documentation updated to match the final rules.
+
+---
+
 ## [1.3.2] - 2025-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -233,4 +233,13 @@ GitHub Actions automatically runs tests on:
 **Note:** Tests run automatically in CI, so you can push your changes and see the results on GitHub.
 
 ## 📄 License
-MIT - [LICENSE](LICENSE) 
+MIT - [LICENSE](LICENSE)
+
+## Paragraph and Inline Text Rules
+
+- Consecutive text blocks are grouped inline by default (in the same paragraph).
+- Any `\n` in a text block always starts a new paragraph (splits the text into multiple paragraphs).
+- `new_paragraph: True` always starts a new paragraph (and resets inline grouping).
+- After a new paragraph (from either `\n` or `new_paragraph: True`), the next inline block starts a new paragraph group.
+- Table cells and headers behave the same way as text blocks: every `\n` creates a new paragraph, and consecutive cell blocks are grouped inline unless `\n` or `new_paragraph: True` is used.
+- `spacing` parameter only applies to blocks with `new_paragraph: True` (adds extra blank paragraphs after that block). For inline text, spacing is ignored. 

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -99,3 +99,12 @@ All blocks that render text support a common style dictionary. This allows for c
 This guide will evolve as more style capabilities are added (e.g., underline, font size, line spacing).
 
 For additional questions or suggestions, please open a GitHub issue or discussion.
+
+## Paragraph and Inline Text Rules
+
+- Consecutive text blocks are grouped inline by default (in the same paragraph).
+- Any `\n` in a text block always starts a new paragraph (splits the text into multiple paragraphs).
+- `new_paragraph: True` always starts a new paragraph (and resets inline grouping).
+- After a new paragraph (from either `\n` or `new_paragraph: True`), the next inline block starts a new paragraph group.
+- Table cells and headers behave the same way as text blocks: every `\n` creates a new paragraph, and consecutive cell blocks are grouped inline unless `\n` or `new_paragraph: True` is used.
+- `spacing` parameter only applies to blocks with `new_paragraph: True` (adds extra blank paragraphs after that block). For inline text, spacing is ignored.

--- a/docxblocks/builders/text.py
+++ b/docxblocks/builders/text.py
@@ -46,8 +46,8 @@ class TextBuilder:
         Build and render a text block in the document.
         
         This method processes the text block, handles empty values with placeholders,
-        and creates new paragraphs for all newlines. It also handles the spacing
-        parameter to add extra blank lines after the text.
+        and either adds text to the current paragraph (inline) or creates new paragraphs.
+        It handles \n by creating new paragraphs, and the spacing parameter to add extra blank lines.
         
         Args:
             block: A validated TextBlock object containing text content and styling
@@ -55,17 +55,44 @@ class TextBuilder:
         # Handle empty text with placeholder
         text = block.text if block.text else DEFAULT_EMPTY_VALUE_TEXT
         
-        # Always process text with newlines since all newlines create new paragraphs
-        paragraphs = process_text_with_newlines(
-            self.doc, text, block.style, 
-            is_empty=(not block.text or not block.text.strip())
-        )
-        
-        # Insert the processed paragraphs
-        for i, para_element in enumerate(paragraphs):
-            self.parent.insert(self.index + i, para_element)
-        self.index += len(paragraphs)
-        self.current_paragraph = None  # Always reset after block
+        if not block.new_paragraph and "\n" not in text:
+            # Inline text - add to current paragraph or create new one if none exists
+            created_new_paragraph = False
+            if self.current_paragraph is None:
+                self.current_paragraph = self.doc.add_paragraph(
+                    style=block.style.style if block.style and block.style.style else "Normal"
+                )
+                self.parent.insert(self.index, self.current_paragraph._element)
+                created_new_paragraph = True
+            
+            # Add text as a run to the current paragraph
+            run = self.current_paragraph.add_run(text)
+            
+            # Apply block style, but override with placeholder style if text is empty
+            if not block.text or not block.text.strip():
+                apply_style_to_run(run, TextStyle(**DEFAULT_EMPTY_VALUE_STYLE))
+            else:
+                apply_style_to_run(run, block.style)
+            
+            if created_new_paragraph:
+                self.index += 1
+        else:
+            # New paragraph or text with newlines - always process with newlines
+            self.current_paragraph = None  # Reset for next inline group
+            
+            # Process text with newlines since \n or new_paragraph is present
+            paragraphs = process_text_with_newlines(
+                self.doc, text, block.style, 
+                is_empty=(not block.text or not block.text.strip())
+            )
+            
+            # Insert the processed paragraphs
+            for i, para_element in enumerate(paragraphs):
+                self.parent.insert(self.index + i, para_element)
+            self.index += len(paragraphs)
+            
+            # After new_paragraph or \n, reset current_paragraph so next inline block starts fresh
+            self.current_paragraph = None
 
         # Handle spacing - add extra blank lines after the text
         if block.spacing and block.spacing > 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "docxblocks"
-version = "1.3.2"
+version = "1.3.3"
 description = "High-level block-based abstraction over python-docx for building dynamic Word documents in code."
 readme = "README.md"
 authors = [

--- a/tests/test_block_order.py
+++ b/tests/test_block_order.py
@@ -102,14 +102,14 @@ def test_mixed_block_types_order(tmp_path):
     assert len(tables) == 1, "Expected 1 table to be present"
 
 def test_inline_text_order(tmp_path):
-    """Test that inline text blocks each create their own paragraph"""
+    """Test that inline text blocks maintain their order and grouping"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
     doc.add_paragraph("{{main}}")
     doc.save(str(template))
 
-    # Create inline text blocks that should each be a paragraph
+    # Create inline text blocks that should stay in order
     blocks = [
         {"type": "text", "text": "First "},
         {"type": "text", "text": "Second "},
@@ -128,10 +128,10 @@ def test_inline_text_order(tmp_path):
     # Get all paragraphs with text content
     paragraphs = [p.text.strip() for p in doc2.paragraphs if p.text.strip()]
 
-    # Each block is now its own paragraph
-    assert len(paragraphs) == 5
-    assert "First" in paragraphs[0]
-    assert "Second" in paragraphs[1]
-    assert "Third" in paragraphs[2]
-    assert "Fourth" in paragraphs[3]
-    assert "Fifth" in paragraphs[4] 
+    # The text builder creates separate paragraphs for each new_paragraph=True block
+    # So we should have: "First Second", "Third", "Fourth", "Fifth"
+    assert len(paragraphs) == 4
+    assert "First Second" in paragraphs[0]
+    assert "Third" in paragraphs[1]
+    assert "Fourth" in paragraphs[2]
+    assert "Fifth" in paragraphs[3] 

--- a/tests/test_inline_text.py
+++ b/tests/test_inline_text.py
@@ -3,7 +3,7 @@ from docx import Document
 from docxblocks.core.inserter import DocxBuilder
 
 def test_inline_text_default(tmp_path):
-    """Test that text blocks each create their own paragraph (no grouping)"""
+    """Test that text blocks are inline by default (no new paragraphs)"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -27,19 +27,24 @@ def test_inline_text_default(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Each block is now its own paragraph
+    # Should have 3 paragraphs: inline text, new paragraph text, inline text after new paragraph
     paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
-    assert len(paragraphs) == 7
-    assert "Participant Name: " in paragraphs[0]
-    assert "John Doe" in paragraphs[1]
-    assert " (ID: " in paragraphs[2]
-    assert "12345" in paragraphs[3]
-    assert ")" in paragraphs[4]
-    assert "New line starts here" in paragraphs[5]
-    assert "This should be on the same line as above" in paragraphs[6]
+    assert len(paragraphs) == 3
+    
+    # First paragraph should contain all the inline text
+    first_para = paragraphs[0]
+    assert "Participant Name: John Doe (ID: 12345)" in first_para
+    
+    # Second paragraph should contain the new paragraph text
+    second_para = paragraphs[1]
+    assert "New line starts here" in second_para
+    
+    # Third paragraph should contain the inline text after the new paragraph
+    third_para = paragraphs[2]
+    assert "This should be on the same line as above" in third_para
 
 def test_mixed_inline_and_paragraphs(tmp_path):
-    """Test mixing inline text with other block types, all text blocks are separate paragraphs"""
+    """Test mixing inline text with other block types"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -62,18 +67,21 @@ def test_mixed_inline_and_paragraphs(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Each text block is now its own paragraph
+    # Should have 3 paragraphs: inline text, heading, inline text
     paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
-    assert len(paragraphs) == 6
-    assert "Status: " in paragraphs[0]
-    assert "Active" in paragraphs[1]
-    assert "Summary" in paragraphs[2]
-    assert "This is a " in paragraphs[3]
-    assert "summary" in paragraphs[4]
-    assert " of the report." in paragraphs[5]
+    assert len(paragraphs) == 3
+    
+    # First paragraph should contain inline status text
+    assert "Status: Active" in paragraphs[0]
+    
+    # Second paragraph should be the heading
+    assert "Summary" in paragraphs[1]
+    
+    # Third paragraph should contain inline summary text
+    assert "This is a summary of the report." in paragraphs[2]
 
 def test_inline_after_new_paragraph(tmp_path):
-    """Test that each text block after a new_paragraph is its own paragraph"""
+    """Test that inline text works correctly after a new_paragraph block"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -92,7 +100,7 @@ def test_inline_after_new_paragraph(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Each block is now its own paragraph
+    # Should have 2 paragraphs: one for each group
     paragraphs = [p.text for p in doc2.paragraphs if p.text.strip()]
     assert len(paragraphs) == 2
     assert "Participant No: " in paragraphs[0]

--- a/tests/test_page_break.py
+++ b/tests/test_page_break.py
@@ -35,7 +35,7 @@ def test_page_break_simple(tmp_path):
     assert "After page break" in text_paragraphs[1].text
 
 def test_page_break_with_inline_text(tmp_path):
-    """Test that page breaks work correctly with each text block as its own paragraph"""
+    """Test that page breaks work correctly with inline text"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -57,10 +57,14 @@ def test_page_break_with_inline_text(tmp_path):
     assert os.path.exists(output)
     doc2 = Document(str(output))
     
-    # Each text block is now its own paragraph
+    # Should have 2 text paragraphs (inline text combined) plus page break
     all_paragraphs = list(doc2.paragraphs)
-    assert len(all_paragraphs) == 5  # Four text paragraphs + page break
-    assert "First page: " in all_paragraphs[0].text
-    assert "inline text" in all_paragraphs[1].text
-    assert "Second page: " in all_paragraphs[3].text
-    assert "more inline text" in all_paragraphs[4].text 
+    assert len(all_paragraphs) == 3  # Two text paragraphs + page break
+    
+    # Check first paragraph has combined inline text
+    first_para = all_paragraphs[0]
+    assert "First page: inline text" in first_para.text
+    
+    # Check second paragraph has combined inline text
+    second_para = all_paragraphs[2]
+    assert "Second page: more inline text" in second_para.text 

--- a/tests/test_text_block.py
+++ b/tests/test_text_block.py
@@ -120,7 +120,7 @@ def test_mixed_newlines(tmp_path):
     assert all_paragraphs[2] == ""  # Empty paragraph from \n\n
 
 def test_spacing_functionality(tmp_path):
-    """Test that spacing parameter adds extra blank lines after text"""
+    """Test that spacing parameter adds extra blank lines after new_paragraph text"""
     template = tmp_path / "template.docx"
     output = tmp_path / "output.docx"
     doc = Document()
@@ -128,9 +128,9 @@ def test_spacing_functionality(tmp_path):
     doc.save(str(template))
 
     blocks = [
-        {"type": "text", "text": "First paragraph"},
-        {"type": "text", "text": "Second paragraph", "spacing": 2},
-        {"type": "text", "text": "Third paragraph"},
+        {"type": "text", "text": "First paragraph", "new_paragraph": True},
+        {"type": "text", "text": "Second paragraph", "new_paragraph": True, "spacing": 2},
+        {"type": "text", "text": "Third paragraph", "new_paragraph": True},
     ]
 
     builder = DocxBuilder(str(template))


### PR DESCRIPTION
### Changed
- Finalized paragraph and inline grouping rules: consecutive text blocks are grouped inline by default, but any `\n` or `new_paragraph: True` always starts a new paragraph and resets grouping.
- After a new paragraph, the next inline block starts a new paragraph group.
- Table cells and headers behave the same way as text blocks.
- `spacing` parameter only applies to blocks with `new_paragraph: True`.

### Fixed
- All tests and documentation updated to match the final rules.
